### PR TITLE
State branch name for HEAD version

### DIFF
--- a/Formula/airdrop-cli.rb
+++ b/Formula/airdrop-cli.rb
@@ -4,7 +4,7 @@ class AirdropCli < Formula
   url "https://github.com/vldmrkl/airdrop-cli/archive/1.0.1.tar.gz"
   sha256 "2e93796692fddb13e362bfd9c204bfc2f24ef22fadaf09efe97201d0bc9b54c3"
   license "MIT"
-  head "https://github.com/vldmrkl/airdrop-cli.git"
+  head "https://github.com/vldmrkl/airdrop-cli.git", branch: "main"
   version "1.0.1"
   depends_on xcode: "11.4"
 


### PR DESCRIPTION
The stable version of `airdrop-cli` on Homebrew lacks the recent updates and did not function properly for me. 

I had to `brew install --HEAD` but there was an error doing that because it looks for a `master` branch by default.